### PR TITLE
add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# venv module files
+venv/


### PR DESCRIPTION
Adds `venv/` to gitignore, ignoring files from the `venv` module.