### PR TITLE
Adding missing 'grid_dim' property to GridDataset

### DIFF
--- a/nata/containers.py
+++ b/nata/containers.py
@@ -322,6 +322,10 @@ class GridDataset(BaseDataset):
     def ndim(self):
         return len(self.shape)
 
+    @property
+    def grid_dim(self):
+        return len(self.axes)
+
     @classmethod
     def from_array(
         cls,


### PR DESCRIPTION
This is a small pull request adding `.grid_dim` property to `GridDatasets`.
