### PR TITLE
fix/GridDataset data setter

### DIFF
--- a/nata/containers.py
+++ b/nata/containers.py
@@ -748,7 +748,7 @@ class GridDataset(np.lib.mixins.NDArrayOperatorsMixin):
             raise ValueError(
                 f"Shapes inconsistent {self.shape} -> {value.shape}"
             )
-        self._data = value
+        self._data = value if len(self) != 1 else value[np.newaxis]
         self._dtype = value.dtype
 
     @property

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -319,6 +319,20 @@ def test_GridDataset_default_Sequence(data, expected_array):
 
 
 def test_GridDataset_change_data():
+    # re-set the data with itself
+    data = np.random.random_sample((1, 10))
+    grid = GridDataset(data)
+
+    assert len(grid) == 1
+    assert grid.shape == (10,)
+    np.testing.assert_array_equal(grid, np.squeeze(data, axis=0))
+
+    grid.data = grid.data
+    assert len(grid) == 1
+    assert grid.shape == (10,)
+    np.testing.assert_array_equal(grid, np.squeeze(data, axis=0))
+
+    # len(ds) == 10
     grid = GridDataset(np.random.random_sample((10,)))
 
     new = np.random.random_sample(grid.shape)


### PR DESCRIPTION
Fixes issue with the setter for `GridDataset` when assining the new data it was
setting the value but required to maintain iteration number and this was
missing.

This commits adds a test where this was failing and implements a fix.

- adds fix for GridDataset.data.setter
- adds failing test
