### PR TITLE
Fixes issues with particle zdf backend

### DIFF
--- a/nata/backends/osiris/zdf.py
+++ b/nata/backends/osiris/zdf.py
@@ -212,14 +212,20 @@ class Osiris_zdf_ParticleFile:
         return z_info.particles.nparts
 
     def get_data(self, indexing=None, fields=None) -> np.ndarray:
+        logging.info(f"Reading data in '{self.location}'")
         (z_data, z_info) = read(str(self.location))
+        if fields is None:
+            # create a structured array
+            dset = np.empty(self.num_particles, dtype=self.dtype)
 
-        # create a structured array
-        dset = np.zeros(self.num_particles, dtype=self.dtype)
-
-        # fill the array
-        for quant in self.quantity_names:
-            dset[quant] = z_data[quant]
+            # fill the array
+            for quant in self.quantity_names:
+                dset[quant] = z_data[quant]
+        else:
+            if indexing is None:
+                dset = z_data[fields][:]
+            else:
+                dset = z_data[fields][indexing]
 
         return dset
 
@@ -241,7 +247,7 @@ class Osiris_zdf_ParticleFile:
         z_info = info(str(self.location))
         names = []
         for quant in self.quantity_names:
-            names.append(z_info.particles.labels[quant])
+            names.append(z_info.particles.qlabels[quant])
         return names
 
     @cached_property
@@ -250,7 +256,7 @@ class Osiris_zdf_ParticleFile:
         z_info = info(str(self.location))
         units = []
         for quant in self.quantity_names:
-            units.append(z_info.particles.units[quant])
+            units.append(z_info.particles.qunits[quant])
 
         return units
 
@@ -261,6 +267,7 @@ class Osiris_zdf_ParticleFile:
         fields = []
         for quant in self.quantity_names:
             fields.append((quant, z_data[quant].dtype))
+
         return np.dtype(fields)
 
     @cached_property

--- a/nata/utils/zdf.py
+++ b/nata/utils/zdf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 """
 Copyright (C) 2017 Instituto Superior Tecnico
 
@@ -478,6 +479,12 @@ class ZDFfile:
             )
             return False
 
+        # Version 0x0001 includes id tag
+        if version >= 1:
+            id = self.__read_uint32()
+        else:
+            id = 0
+
         data_type = self.__read_int32()
         ndims = self.__read_uint32()
         nx = self.__read_uint64_arr(ndims)
@@ -555,6 +562,7 @@ class ZDFfile:
             name = rec.name
 
             if name == chunk_name:
+                chunk_id = self.__read_uint32()
                 count = self.__read_int64_arr(ndims)
                 start = self.__read_int64_arr(ndims)
                 stride = self.__read_int64_arr(ndims)


### PR DESCRIPTION
The method `get_data()` of `Osiris_zdf_ParticleFile` would raise an error due to type mismatch between each particle quantity's `dtype` property and `Osiris_zdf_ParticleFile.dtype`. This occurred because `get_data()` ignored the parameters `indexing` and `fields`,  which are used to make a subselection of the data to be read from the file(s).