### PR TITLE
Particle filter mask

### DIFF
--- a/nata/plugins/particles/filter.py
+++ b/nata/plugins/particles/filter.py
@@ -58,7 +58,7 @@ def filter_particle_dataset(
 
     if mask is not None:
         for name, quant in quants.items():
-            quants[name].data.mask = np.invert(mask)
+            quants[name].data[~mask] = np.ma.masked
 
     return ParticleDataset(
         iteration=dataset_c.axes["iteration"],

--- a/nata/plugins/particles/filter.py
+++ b/nata/plugins/particles/filter.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from copy import deepcopy
 from typing import List
+
+import numpy as np
 
 from nata.containers import ParticleDataset
 from nata.plugins.register import register_container_plugin
@@ -7,13 +10,20 @@ from nata.plugins.register import register_container_plugin
 
 @register_container_plugin(ParticleDataset, name="filter")
 def filter_particle_dataset(
-    dataset: ParticleDataset, quantities: List[str]
+    dataset: ParticleDataset,
+    mask: List[bool] = None,
+    quantities: List[str] = None,
 ) -> ParticleDataset:
     """Filters a :class:`nata.containers.ParticleDataset` according to a\
        selection of quantities.
 
         Parameters
         ----------
+        mask: ``np.ndarray``
+            Array of booleans indicating the particles to be filtered. Particles
+            with ``True`` (``False``) mask entries are selected (hidden). The
+            shape of ``mask`` must match that of each particle quantity.
+
         quantities: ``list``
             List of quantities to be filtered, ordered by the way they should be
             sorted in the returned dataset.
@@ -35,20 +45,24 @@ def filter_particle_dataset(
 
     """
 
+    dataset_c = deepcopy(dataset)
+
     if quantities is not None:
-        quants = {}
-        for quant in quantities:
-            quants[quant] = (
-                dataset.quantities[quant]
-                if quant in dataset.quantities.keys()
-                else None
-            )
+        quants = {
+            quant: dataset_c.quantities[quant]
+            for quant in quantities
+            if quant in dataset_c.quantities
+        }
     else:
-        raise ValueError("")
+        quants = dataset_c.quantities
+
+    if mask is not None:
+        for name, quant in quants.items():
+            quants[name].data.mask = np.invert(mask)
 
     return ParticleDataset(
-        iteration=dataset.axes["iteration"],
-        time=dataset.axes["time"],
-        name=dataset.name,
+        iteration=dataset_c.axes["iteration"],
+        time=dataset_c.axes["time"],
+        name=dataset_c.name,
         quantities=quants,
     )

--- a/nata/plugins/plot/particle.py
+++ b/nata/plugins/plot/particle.py
@@ -29,7 +29,7 @@ def particle_plot_data(dataset: ParticleDataset) -> PlotData:
         )
 
         a.append(new_a)
-        d.append(np.array(quant))
+        d.append(quant.data)
 
     return PlotData(
         name=dataset.name,


### PR DESCRIPTION
Adds a `mask` argument to the `ParticleDataset.filter()` plugin. This `mask` should be an array of booleans which shape matches that of any particle quantity. Particles with a corresponding `True` (`False`) entry in `mask` are kept visible (hidden).

For example, the following code will plot only particles that respect `x1 > 0`: 

```python
dataset.filter(
    mask = dataset.quantities["x1"].data > 0
).plot()
```