### PR TITLE
Adds slicing to ParticleDataset filter plugin

### DIFF
--- a/nata/plugins/particles/filter.py
+++ b/nata/plugins/particles/filter.py
@@ -21,12 +21,18 @@ def filter_particle_dataset(
 
         Parameters
         ----------
-        mask: ``np.ndarray``
+        mask: ``np.ndarray``, optional
             Array of booleans indicating the particles to be filtered. Particles
             with ``True`` (``False``) mask entries are selected (hidden). The
             shape of ``mask`` must match that of each particle quantity.
 
-        quantities: ``list``
+        slicing: ``slice``, optional
+            Slice of particles to be filtered. Acts only on particle indices
+            and not on time, as time slicing should be done on the dataset.
+            When provided together with the ``mask argument``, slicing is done
+            on the masked array.
+
+        quantities: ``list``, optional
             List of quantities to be filtered, ordered by the way they should be
             sorted in the returned dataset.
 
@@ -63,7 +69,6 @@ def filter_particle_dataset(
             quants[name].data[~mask] = np.ma.masked
 
     if slicing is not None:
-        # allow particle index slicing only for now
         if len(quant) > 1:
             slicing = (slice(None), slicing)
 

--- a/nata/plugins/particles/filter.py
+++ b/nata/plugins/particles/filter.py
@@ -5,6 +5,7 @@ from typing import List
 import numpy as np
 
 from nata.containers import ParticleDataset
+from nata.containers import ParticleQuantity
 from nata.plugins.register import register_container_plugin
 
 
@@ -13,6 +14,7 @@ def filter_particle_dataset(
     dataset: ParticleDataset,
     mask: List[bool] = None,
     quantities: List[str] = None,
+    slicing: slice = None,
 ) -> ParticleDataset:
     """Filters a :class:`nata.containers.ParticleDataset` according to a\
        selection of quantities.
@@ -59,6 +61,22 @@ def filter_particle_dataset(
     if mask is not None:
         for name, quant in quants.items():
             quants[name].data[~mask] = np.ma.masked
+
+    if slicing is not None:
+        # allow particle index slicing only for now
+        if len(quant) > 1:
+            slicing = (slice(None), slicing)
+
+        quants = {
+            quant.name: ParticleQuantity(
+                data=quant.data[slicing],
+                name=quant.name,
+                label=quant.label,
+                unit=quant.unit,
+                dtype=quant.data.dtype,
+            )
+            for quant in quants.values()
+        }
 
     return ParticleDataset(
         iteration=dataset_c.axes["iteration"],

--- a/nata/plugins/particles/filter.py
+++ b/nata/plugins/particles/filter.py
@@ -56,19 +56,44 @@ def filter_particle_dataset(
     dataset_c = deepcopy(dataset)
 
     if quantities is not None:
+        if not isinstance(quantities, list) or not all(
+            isinstance(quant, str) for quant in quantities
+        ):
+            raise TypeError(f"'quantities' must be a list of strings.")
+
         quants = {
             quant: dataset_c.quantities[quant]
             for quant in quantities
-            if quant in dataset_c.quantities
+            if quant in dataset_c.quantities.keys()
         }
+
+        if not bool(quants):
+            raise ValueError(
+                f"None of the quantities in 'quantities' were found in the "
+                + "dataset."
+            )
+
     else:
         quants = dataset_c.quantities
 
     if mask is not None:
+        if not isinstance(mask, np.ndarray) or not mask.dtype == bool:
+            raise TypeError(f"'mask' must be an 'np.ndarray' of dtype 'bool'.")
+
+        quant = next(iter(quants.values()))
+        if quant.data.shape != mask.shape:
+            raise ValueError(
+                f"'mask.shape' ({mask.shape}) does not match the shape of "
+                + "each quantity ({quant.data.shape})."
+            )
+
         for name, quant in quants.items():
             quants[name].data[~mask] = np.ma.masked
 
     if slicing is not None:
+        if not isinstance(slicing, slice):
+            raise TypeError(f"'slicing' must be of type 'slice'.")
+
         if len(quant) > 1:
             slicing = (slice(None), slicing)
 


### PR DESCRIPTION
Adds a `slicing` argument to the `ParticleDataset.filter()` plugin. This should be a slice to act on particle indices, e.g. `slicing=slice(50, 1000, 10)` will select every 10th particle between entries 50 and 1000 of each quantity's data array. Time slicing is not available in this plugin, as it should be done using slicing on the dataset itself, e.g. `dataset[10:50]`.  When provided together with the `mask` argument, the slicing is done on the masked array.

This is useful to produce faster particle quantity plots while exploratory the data, for example:
```python
dataset.filter(
    mask=(dataset.quantities["x1"].data > 0),
    slicing=slice(None, None, 50)
).plot() 
```