### PR TITLE
Using prefetch for backend properties

### DIFF
--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -331,16 +331,12 @@ class Osiris_Hdf5_ParticleFile:
         if isinstance(path, str):
             path = Path(path)
 
-        if not isinstance(path, Path):
-            return False
-
-        if not path.is_file():
-            return False
-
-        if not path.suffix == ".h5":
-            return False
-
-        if not h5.is_hdf5(path):
+        if (
+            not isinstance(path, Path)
+            or not path.is_file()
+            or not path.suffix == ".h5"
+            or not h5.is_hdf5(path)
+        ):
             return False
 
         with h5.File(path, mode="r") as f:

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -449,27 +449,21 @@ class Osiris_Dev_Hdf5_ParticleFile:
         )
 
     @staticmethod
-    def is_valid_backend(file_path: FileLocation) -> bool:
-        if isinstance(file_path, str):
-            file_path = Path(file_path)
+    def is_valid_backend(path: FileLocation) -> bool:
+        if isinstance(path, str):
+            path = Path(path)
 
-        if not isinstance(file_path, Path):
+        if (
+            not isinstance(path, Path)
+            or not path.is_file()
+            or not path.suffix == ".h5"
+            or not h5.is_hdf5(path)
+        ):
             return False
 
-        if not file_path.is_file():
-            return False
-
-        if not file_path.suffix == ".h5":
-            return False
-
-        if not h5.is_hdf5(file_path):
-            return False
-
-        with h5.File(file_path, mode="r") as f:
+        with h5.File(path, mode="r") as f:
             if ("TYPE" in f.attrs) and ("LABELS" in f.attrs):
-                type_ = f.attrs["TYPE"].astype(str)[0]
-
-                if type_ == "particles":
+                if f.attrs["TYPE"].astype(str)[0] == "particles":
                     return True
 
         return False

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -3,7 +3,6 @@ from logging import info
 from pathlib import Path
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 import h5py as h5
@@ -26,21 +25,58 @@ class Osiris_Hdf5_GridFile:
             location if isinstance(location, Path) else Path(location)
         )
 
+        info(f"Obtaining backend props for '{self.location}'")
+        with h5.File(self.location, mode="r") as fp:
+            short_name = fp.attrs["NAME"].astype(str)[0]
+            if short_name in fp:
+                self._dset_name = short_name
+            else:
+                name_ = short_name.split()[-1]
+                self._dset_name = name_.replace("_", "")
+
+            self._dataset_name = fp.attrs["NAME"].astype(str)[0]
+            self._dataset_label = (
+                fp[self._dset_name].attrs["LONG_NAME"].astype(str)[0]
+            )
+            self._ndim = fp[self._dset_name].ndim
+            self._shape = fp[self._dset_name].shape[::-1]
+            self._dtype = fp[self._dset_name].dtype
+            self._units = fp[self._dset_name].attrs["UNITS"].astype(str)[0]
+
+            min_, max_ = [], []
+            axes_names, axes_labels, axes_units = [], [], []
+            for ax in fp["AXIS"]:
+                min_.append(fp["AXIS/" + ax][0])
+                max_.append(fp["AXIS/" + ax][1])
+                axes_names.append(fp["AXIS/" + ax].attrs["NAME"].astype(str)[0])
+                axes_labels.append(
+                    fp["AXIS/" + ax].attrs["LONG_NAME"].astype(str)[0]
+                )
+                axes_units.append(
+                    fp["AXIS/" + ax].attrs["UNITS"].astype(str)[0]
+                )
+
+            self._min = np.array(min_)
+            self._max = np.array(max_)
+            self._axes_names = np.array(axes_names)
+            self._axes_labels = np.array(axes_labels)
+            self._axes_units = np.array(axes_units)
+
+            self._iteration = fp.attrs["ITER"].astype(int)[0]
+            self._time_step = fp.attrs["TIME"][0]
+            self._time_unit = fp.attrs["TIME UNITS"].astype(str)[0]
+
     @staticmethod
     def is_valid_backend(path: Union[Path, str]) -> bool:
         if isinstance(path, str):
             path = Path(path)
 
-        if not isinstance(path, Path):
-            return False
-
-        if not path.is_file():
-            return False
-
-        if not path.suffix == ".h5":
-            return False
-
-        if not h5.is_hdf5(path):
+        if (
+            not isinstance(path, Path)
+            or not path.is_file()
+            or not path.suffix == ".h5"
+            or not h5.is_hdf5(path)
+        ):
             return False
 
         with h5.File(path, mode="r") as f:
@@ -49,10 +85,10 @@ class Osiris_Hdf5_GridFile:
                 and ("TYPE" in f.attrs)
                 and ("LABEL" not in f.attrs)
             ):
-                type_: str = f.attrs["TYPE"].astype(str)[0]
+                type_ = f.attrs["TYPE"].astype(str)[0]
                 # general naming
-                name_: str = f.attrs["NAME"].astype(str)[0]
-                names: Tuple[str, ...] = (name_,)
+                name_ = f.attrs["NAME"].astype(str)[0]
+                names = (name_,)
                 # special case naming
                 name_ = name_.split()[-1]
                 name_ = name_.replace("_", "")
@@ -63,18 +99,6 @@ class Osiris_Hdf5_GridFile:
 
         return False
 
-    @cached_property
-    def _dset_name(self) -> str:
-        with h5.File(self.location, mode="r") as fp:
-            short_name = fp.attrs["NAME"].astype(str)[0]
-            if short_name in fp:
-                return short_name
-
-            name_ = short_name.split()[-1]
-            name_ = name_.replace("_", "")
-            if name_ in fp:
-                return name_
-
     def get_data(self, indexing=None):
         info(f"Reading data in '{self.location}'")
         # TODO: apply indexing here
@@ -84,113 +108,61 @@ class Osiris_Hdf5_GridFile:
             dset.read_direct(dataset)
         return dataset.transpose()
 
-    @cached_property
+    @property
     def dataset_name(self) -> str:
-        info(f"Accessing '{self.location}' for 'dataset_name'")
-        with h5.File(self.location, mode="r") as fp:
-            return fp.attrs["NAME"].astype(str)[0]
+        return self._dataset_name
 
-    @cached_property
+    @property
     def dataset_label(self) -> str:
-        info(f"Accessing '{self.location}' for 'dataset_label'")
-        with h5.File(self.location, mode="r") as fp:
-            return fp[self._dset_name].attrs["LONG_NAME"].astype(str)[0]
+        return self._dataset_label
 
-    @cached_property
+    @property
     def ndim(self):
-        info(f"Accessing '{self.location}' for 'ndim'")
-        with h5.File(self.location, mode="r") as fp:
-            ndim = fp[self._dset_name].ndim
-        return ndim
+        return self._ndim
 
-    @cached_property
+    @property
     def shape(self):
-        info(f"Accessing '{self.location}' for 'shape'")
-        with h5.File(self.location, mode="r") as fp:
-            return fp[self._dset_name].shape[::-1]
+        return self._shape
 
-    @cached_property
+    @property
     def dtype(self):
-        info(f"Accessing '{self.location}' for 'dtype'")
-        with h5.File(self.location, mode="r") as fp:
-            dtype = fp[self._dset_name].dtype
-        return dtype
+        return self._dtype
 
-    @cached_property
+    @property
     def dataset_unit(self):
-        info(f"Accessing '{self.location}' for 'dataset_unit'")
-        with h5.File(self.location, mode="r") as fp:
-            units = fp[self._dset_name].attrs["UNITS"].astype(str)[0]
-        return units
+        return self._units
 
-    @cached_property
+    @property
     def axes_min(self):
-        info(f"Accessing '{self.location}' for 'axes_min'")
-        min_ = []
-        with h5.File(self.location, mode="r") as fp:
-            for axis in fp["AXIS"]:
-                min_.append(fp["AXIS/" + axis][0])
-        return np.array(min_)
+        return self._min
 
-    @cached_property
+    @property
     def axes_max(self):
-        info(f"Accessing '{self.location}' for 'axes_max'")
-        max_ = []
-        with h5.File(self.location, mode="r") as fp:
-            for axis in fp["AXIS"]:
-                max_.append(fp["AXIS/" + axis][1])
+        return self._max
 
-        return np.array(max_)
-
-    @cached_property
+    @property
     def axes_names(self):
-        info(f"Accessing '{self.location}' for 'axes_names'")
-        names = []
-        with h5.File(self.location, mode="r") as fp:
-            for axis in fp["AXIS"]:
-                names.append(fp["AXIS/" + axis].attrs["NAME"].astype(str)[0])
-        return np.array(names)
+        return self._axes_names
 
-    @cached_property
+    @property
     def axes_labels(self):
-        info(f"Accessing '{self.location}' for 'axes_labels'")
-        long_names = []
-        with h5.File(self.location, mode="r") as fp:
-            for axis in fp["AXIS"]:
-                long_names.append(
-                    fp["AXIS/" + axis].attrs["LONG_NAME"].astype(str)[0]
-                )
-        return np.array(long_names)
+        return self._axes_labels
 
-    @cached_property
+    @property
     def axes_units(self):
-        info(f"Accessing '{self.location}' for 'axes_units'")
-        units = []
-        with h5.File(self.location, mode="r") as fp:
-            for axis in fp["AXIS"]:
-                units.append(fp["AXIS/" + axis].attrs["UNITS"].astype(str)[0])
-        return np.array(units)
+        return self._axes_units
 
-    @cached_property
+    @property
     def iteration(self):
-        info(f"Accessing '{self.location}' for 'iteration'")
-        with h5.File(self.location, mode="r") as fp:
-            time_step = fp.attrs["ITER"].astype(int)[0]
-        return time_step
+        return self._iteration
 
-    @cached_property
+    @property
     def time_step(self):
-        info(f"Accessing '{self.location}' for 'time_step'")
-        with h5.File(self.location, mode="r") as fp:
-            time = fp.attrs["TIME"][0]
-        return time
+        return self._time_step
 
-    @cached_property
+    @property
     def time_unit(self):
-        info(f"Accessing '{self.location}' for 'time_unit'")
-        with h5.File(self.location, mode="r") as fp:
-            time_unit = fp.attrs["TIME UNITS"].astype(str)[0]
-        return time_unit
+        return self._time_unit
 
 
 @register_backend(GridDataset)

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -251,12 +251,12 @@ class Osiris_Dev_Hdf5_GridFile:
         return False
 
     def get_data(self, indexing=None):
-        # TODO: apply indexing here
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
-            dset = fp[self._dset_name]
-            dataset = np.zeros(dset.shape, dtype=dset.dtype)
-            dset.read_direct(dataset)
+            if indexing:
+                dataset = fp[self._dset_name][indexing[::-1]]
+            else:
+                dataset = fp[self._dset_name][:]
         return dataset.transpose()
 
     @property

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -390,7 +390,7 @@ class Osiris_Hdf5_ParticleFile:
 
     @property
     def time_step(self) -> float:
-        return self._time_steps
+        return self._time_step
 
     @property
     def time_unit(self) -> str:

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -176,23 +176,19 @@ class Osiris_Dev_Hdf5_GridFile:
         )
 
     @staticmethod
-    def is_valid_backend(file_path: Union[Path, str]) -> bool:
-        if isinstance(file_path, str):
-            file_path = Path(file_path)
+    def is_valid_backend(path: Union[Path, str]) -> bool:
+        if isinstance(path, str):
+            path = Path(path)
 
-        if not isinstance(file_path, Path):
+        if (
+            not isinstance(path, Path)
+            or not path.is_file()
+            or not path.suffix == ".h5"
+            or not h5.is_hdf5(path)
+        ):
             return False
 
-        if not file_path.is_file():
-            return False
-
-        if not file_path.suffix == ".h5":
-            return False
-
-        if not h5.is_hdf5(file_path):
-            return False
-
-        with h5.File(file_path, mode="r") as f:
+        with h5.File(path, mode="r") as f:
             if (
                 ("NAME" in f.attrs)
                 and ("TYPE" in f.attrs)

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from nata.containers import GridDataset
 from nata.containers import ParticleDataset
+from nata.types import FileLocation
 from nata.utils.backends import sort_particle_quantities
 from nata.utils.cached_property import cached_property
 from nata.utils.container_tools import register_backend
@@ -67,7 +68,7 @@ class Osiris_Hdf5_GridFile:
             self._time_unit = fp.attrs["TIME UNITS"].astype(str)[0]
 
     @staticmethod
-    def is_valid_backend(path: Union[Path, str]) -> bool:
+    def is_valid_backend(path: FileLocation) -> bool:
         if isinstance(path, str):
             path = Path(path)
 
@@ -170,13 +171,13 @@ class Osiris_Dev_Hdf5_GridFile:
     name = "osiris_dev_grid_hdf5"
     location: Optional[Path] = None
 
-    def __init__(self, location: Union[str, Path]) -> None:
+    def __init__(self, location: FileLocation) -> None:
         self.location = (
             location if isinstance(location, Path) else Path(location)
         )
 
     @staticmethod
-    def is_valid_backend(path: Union[Path, str]) -> bool:
+    def is_valid_backend(path: FileLocation) -> bool:
         if isinstance(path, str):
             path = Path(path)
 
@@ -349,7 +350,7 @@ class Osiris_Hdf5_ParticleFile:
         )
 
     @staticmethod
-    def is_valid_backend(path: Union[Path, str]) -> bool:
+    def is_valid_backend(path: FileLocation) -> bool:
         if isinstance(path, str):
             path = Path(path)
 
@@ -485,7 +486,7 @@ class Osiris_Dev_Hdf5_ParticleFile:
         )
 
     @staticmethod
-    def is_valid_backend(file_path: Union[Path, str]) -> bool:
+    def is_valid_backend(file_path: FileLocation) -> bool:
         if isinstance(file_path, str):
             file_path = Path(file_path)
 

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -341,9 +341,7 @@ class Osiris_Hdf5_ParticleFile:
 
         with h5.File(path, mode="r") as f:
             if ("TYPE" in f.attrs) and ("LABELS" not in f.attrs):
-                type_ = f.attrs["TYPE"].astype(str)[0]
-
-                if type_ == "particles":
+                if f.attrs["TYPE"].astype(str)[0] == "particles":
                     return True
 
         return False

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -3,6 +3,7 @@ from logging import info
 from pathlib import Path
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Union
 
 import h5py as h5
@@ -10,6 +11,8 @@ import numpy as np
 
 from nata.containers import GridDataset
 from nata.containers import ParticleDataset
+from nata.types import BasicIndex
+from nata.types import BasicIndexing
 from nata.types import FileLocation
 from nata.utils.backends import sort_particle_quantities
 from nata.utils.container_tools import register_backend
@@ -99,7 +102,7 @@ class Osiris_Hdf5_GridFile:
 
         return False
 
-    def get_data(self, indexing=None):
+    def get_data(self, indexing: Optional[BasicIndexing] = None) -> np.ndarray:
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
             if indexing:
@@ -249,7 +252,7 @@ class Osiris_Dev_Hdf5_GridFile:
 
         return False
 
-    def get_data(self, indexing=None):
+    def get_data(self, indexing: Optional[BasicIndexing] = None) -> np.ndarray:
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
             if indexing:
@@ -415,7 +418,11 @@ class Osiris_Hdf5_ParticleFile:
 
         return False
 
-    def get_data(self, indexing=None, fields=None) -> np.ndarray:
+    def get_data(
+        self,
+        indexing: Optional[BasicIndex] = None,
+        fields: Optional[Union[str, Sequence[str]]] = None,
+    ) -> np.ndarray:
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
             if fields is None:
@@ -534,7 +541,11 @@ class Osiris_Dev_Hdf5_ParticleFile:
 
         return False
 
-    def get_data(self, indexing=None, fields=None) -> np.ndarray:
+    def get_data(
+        self,
+        indexing: Optional[BasicIndex] = None,
+        fields: Optional[Union[str, Sequence[str]]] = None,
+    ) -> np.ndarray:
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
             if fields is None:

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -321,7 +321,7 @@ class Osiris_Hdf5_ParticleFile:
     name = "osiris_4.4.4_particles_hdf5"
     location: Optional[Path] = None
 
-    def __init__(self, location=Union[str, Path]) -> None:
+    def __init__(self, location: FileLocation) -> None:
         self.location = (
             location if isinstance(location, Path) else Path(location)
         )

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -9,6 +9,7 @@ from typing import Union
 import h5py as h5
 import numpy as np
 
+import ndindex as ndx
 from nata.containers import GridDataset
 from nata.containers import ParticleDataset
 from nata.types import BasicIndex
@@ -425,21 +426,21 @@ class Osiris_Hdf5_ParticleFile:
     ) -> np.ndarray:
         info(f"Reading data in '{self.location}'")
         with h5.File(self.location, mode="r") as fp:
-            if fields is None:
-                # create a structured array
-                dset = np.empty(self.num_particles, dtype=self.dtype)
+            index = (
+                ndx.Slice(None) if indexing is None else ndx.ndindex(indexing)
+            )
+            index = index.reduce((self.num_particles,))
+            dtype = self.dtype if fields is None else self.dtype[fields]
 
-                # fill the array
-                for quant in self.quantity_names:
-                    dset[quant] = fp[quant]
+            if dtype.fields:
+                # create array as source to store quantities
+                dset = np.empty(len(index), dtype=dtype)
+
+                for field in dtype.fields:
+                    dset[field][:] = fp[field][index.raw]
             else:
-                if indexing is None:
-                    if fp[fields].shape:
-                        dset = fp[fields][:]
-                    else:
-                        dset = np.empty(0, dtype=self.dtype[fields])
-                else:
-                    dset = fp[fields][indexing]
+                # only one field element -> string passed
+                dset = fp[fields][index.raw]
 
         return dset
 

--- a/nata/backends/osiris/hdf5.py
+++ b/nata/backends/osiris/hdf5.py
@@ -101,11 +101,11 @@ class Osiris_Hdf5_GridFile:
 
     def get_data(self, indexing=None):
         info(f"Reading data in '{self.location}'")
-        # TODO: apply indexing here
         with h5.File(self.location, mode="r") as fp:
-            dset = fp[self._dset_name]
-            dataset = np.zeros(dset.shape, dtype=dset.dtype)
-            dset.read_direct(dataset)
+            if indexing:
+                dataset = fp[self._dset_name][indexing[::-1]]
+            else:
+                dataset = fp[self._dset_name][:]
         return dataset.transpose()
 
     @property

--- a/nata/types.py
+++ b/nata/types.py
@@ -161,7 +161,7 @@ class GridBackendType(BackendType, Protocol):
 class GridDataReader(GridBackendType, Protocol):
     """Extended backend which handles grid data reading"""
 
-    def get_data(self, indexing=Optional[BasicIndexing]) -> np.ndarray:
+    def get_data(self, indexing: Optional[BasicIndexing] = None) -> np.ndarray:
         """Routine for reading underlaying grid data.
 
         Parameters
@@ -228,8 +228,8 @@ class ParticleDataReader(ParticleBackendType, Protocol):
 
     def get_data(
         self,
-        indexing=Optional[BasicIndex],
-        fields=Optional[Union[str, Sequence[str]]],
+        indexing: Optional[BasicIndex] = None,
+        fields: Optional[Union[str, Sequence[str]]] = None,
     ) -> np.ndarray:
         """Routine for reading underlaying grid data.
 

--- a/nata/types.py
+++ b/nata/types.py
@@ -48,6 +48,23 @@ def is_basic_indexing(key: Any):
     return False
 
 
+#: Scalars and numbers
+Number = Union[float, int]
+
+#: Type which can be supplied to `numpy.array` and the resulting output is an
+#: array
+ArrayLike = Union[np.ndarray, Sequence[Number]]
+
+#: Type for basic indexing
+BasicIndex = Union[int, slice]
+
+#: Type for basic indexing
+BasicIndexing = Union[BasicIndex, Tuple[BasicIndex, ...]]
+
+#: Type for file location
+FileLocation = Union[Path, str]
+
+
 @runtime_checkable
 class BackendType(Protocol):
     """General type for retreiving data.
@@ -144,10 +161,7 @@ class GridBackendType(BackendType, Protocol):
 class GridDataReader(GridBackendType, Protocol):
     """Extended backend which handles grid data reading"""
 
-    def get_data(
-        self,
-        indexing=Optional[Union[int, slice, Tuple[Union[slice, int], ...]]],
-    ) -> np.ndarray:
+    def get_data(self, indexing=Optional[BasicIndexing]) -> np.ndarray:
         """Routine for reading underlaying grid data.
 
         Parameters
@@ -214,7 +228,7 @@ class ParticleDataReader(ParticleBackendType, Protocol):
 
     def get_data(
         self,
-        indexing=Optional[Union[int, slice, Tuple[slice, int]]],
+        indexing=Optional[BasicIndex],
         fields=Optional[Union[str, Sequence[str]]],
     ) -> np.ndarray:
         """Routine for reading underlaying grid data.
@@ -517,17 +531,3 @@ class ParticleDatasetType(DatasetType, Protocol):
     #: Axes for `ParticleDatasetType`. It is a dictionary of type
     #: `ParticleDatasetAxes`.
     axes: ParticleDatasetAxes
-
-
-#: Scalars and numbers
-Number = Union[float, int]
-
-#: Type which can be supplied to `numpy.array` and the resulting output is an
-#: array
-ArrayLike = Union[np.ndarray, Sequence[Number]]
-
-#: Type for basic indexing
-BasicIndexing = Union[int, slice, Tuple[Union[slice, int], ...]]
-
-#: Type for file location
-FileLocation = Union[Path, str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ sphinx = {version = "^3.0.3", optional = true}
 sphinx-rtd-theme = {version = "^0.4.3", optional = true}
 recommonmark = {version = "^0.6.0", optional = true}
 jupyterlab = {version = "^2.1.2", optional = true}
+ndindex = "^1.3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = ">5.0"

--- a/tests/backends/osiris/test_GridFile.py
+++ b/tests/backends/osiris/test_GridFile.py
@@ -79,7 +79,6 @@ def _generate_valid_Osiris_Hdf5_GridFile(tmp_path_factory):
     return file_
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' is a valid backend exclusively"""
     assert Osiris_Hdf5_GridFile.is_valid_backend(os_hdf5_grid_444_file) is True
@@ -92,7 +91,6 @@ def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
         assert backend.is_valid_backend(os_hdf5_grid_444_file) is False
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_dataset_props(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' dataset properties"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
@@ -106,7 +104,6 @@ def test_Osiris_Hdf5_GridFile_dataset_props(os_hdf5_grid_444_file):
     assert backend.ndim == 3
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' extraction of axes properties"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
@@ -123,14 +120,12 @@ def test_Osiris_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_444_file):
     np.testing.assert_array_equal(backend.axes_max, [2, 3, 4])
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_iteration_props(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' extraction of iteration"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     assert backend.iteration == 12345
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' extraction of time props"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
@@ -138,7 +133,6 @@ def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
     assert backend.time_unit == "time unit"
 
 
-@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_reading_data(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' reading array correctly"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
@@ -203,7 +197,6 @@ def _generate_valid_Osiris_Dev_Hdf5_GridFile(tmp_path_factory):
     return file_
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_dev_file):
     """Check 'Osiris_Hdf5_GridFile' is a valid backend exclusively"""
     assert (
@@ -218,7 +211,6 @@ def test_Osiris_Dev_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_dev_file):
         assert backend.is_valid_backend(os_hdf5_grid_dev_file) is False
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_dataset_props(os_hdf5_grid_dev_file):
     """Check 'Osiris_Dev_Hdf5_GridFile' dataset properties"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
@@ -232,7 +224,6 @@ def test_Osiris_Dev_Hdf5_GridFile_dataset_props(os_hdf5_grid_dev_file):
     assert backend.ndim == 3
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_dev_file):
     """Check 'Osiris_Dev_Hdf5_GridFile' extraction of axes properties"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
@@ -249,14 +240,12 @@ def test_Osiris_Dev_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_dev_file):
     np.testing.assert_array_equal(backend.axes_max, [2, 3, 4])
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_iteration_props(os_hdf5_grid_dev_file):
     """Check 'Osiris_Dev_Hdf5_GridFile' extraction of iteration"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     assert backend.iteration == 12345
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_time_props(os_hdf5_grid_dev_file):
     """Check 'Osiris_Dev_Hdf5_GridFile' extraction of time props"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
@@ -264,7 +253,6 @@ def test_Osiris_Dev_Hdf5_GridFile_time_props(os_hdf5_grid_dev_file):
     assert backend.time_unit == "time unit"
 
 
-@pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_reading_data(os_hdf5_grid_dev_file):
     """Check 'Osiris_Dev_Hdf5_GridFile' reading array correctly"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)

--- a/tests/backends/osiris/test_GridFile.py
+++ b/tests/backends/osiris/test_GridFile.py
@@ -94,6 +94,7 @@ def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
 
 @pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_dataset_props(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' dataset properties"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     # TODO: check if dataset name is valid identifier
     assert backend.dataset_name == "test ds"
@@ -107,6 +108,7 @@ def test_Osiris_Hdf5_GridFile_dataset_props(os_hdf5_grid_444_file):
 
 @pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' extraction of axes properties"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     # TODO: check if axis names are valid identifier
     expected_names = ("axis1 name", "axis2 name", "axis3 name")
@@ -123,12 +125,14 @@ def test_Osiris_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_444_file):
 
 @pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_iteration_props(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' extraction of iteration"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     assert backend.iteration == 12345
 
 
 @pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' extraction of time props"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     np.testing.assert_allclose(backend.time_step, -321.9)
     assert backend.time_unit == "time unit"
@@ -136,6 +140,7 @@ def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
 
 @pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_reading_data(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' reading array correctly"""
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     full_array = np.arange(24, dtype="f4").reshape((2, 3, 4))
 
@@ -215,6 +220,7 @@ def test_Osiris_Dev_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_dev_file):
 
 @pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_dataset_props(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Dev_Hdf5_GridFile' dataset properties"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     # TODO: check if dataset name is valid identifier
     assert backend.dataset_name == "test ds"
@@ -228,6 +234,7 @@ def test_Osiris_Dev_Hdf5_GridFile_dataset_props(os_hdf5_grid_dev_file):
 
 @pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Dev_Hdf5_GridFile' extraction of axes properties"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     # TODO: check if axis names are valid identifier
     expected_names = ("axis1 name", "axis2 name", "axis3 name")
@@ -244,12 +251,14 @@ def test_Osiris_Dev_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_dev_file):
 
 @pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_iteration_props(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Dev_Hdf5_GridFile' extraction of iteration"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     assert backend.iteration == 12345
 
 
 @pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_time_props(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Dev_Hdf5_GridFile' extraction of time props"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     np.testing.assert_allclose(backend.time_step, -321.9)
     assert backend.time_unit == "time unit"
@@ -257,6 +266,7 @@ def test_Osiris_Dev_Hdf5_GridFile_time_props(os_hdf5_grid_dev_file):
 
 @pytest.mark.wip
 def test_Osiris_Dev_Hdf5_GridFile_reading_data(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Dev_Hdf5_GridFile' reading array correctly"""
     backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
     full_array = np.arange(24, dtype="f4").reshape((2, 3, 4))
 

--- a/tests/backends/osiris/test_GridFile.py
+++ b/tests/backends/osiris/test_GridFile.py
@@ -147,3 +147,124 @@ def test_Osiris_Hdf5_GridFile_reading_data(os_hdf5_grid_444_file):
     np.testing.assert_array_equal(
         backend.get_data(indexing=index), full_array[index]
     )
+
+
+@pytest.fixture(name="os_hdf5_grid_dev_file", scope="session")
+def _generate_valid_Osiris_Dev_Hdf5_GridFile(tmp_path_factory):
+    """Fixture for valid HDF5 file for Osiris_Hdf5_GridFile backend"""
+    tmp_path = tmp_path_factory.mktemp("os_hdf5_grid_dev_fixture")
+    file_ = tmp_path / "os_hdf5_grid_dev_file.h5"
+    dtype = np.dtype("f4")
+
+    with h5.File(file_, mode="w") as fp:
+        # root attrs
+        fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
+        fp.attrs["TYPE"] = np.array([b"grid"], dtype="|S4")
+        fp.attrs["LABEL"] = np.array(
+            [b"\\Latex test dataset label"], dtype="|S256"
+        )
+        fp.attrs["ITER"] = np.array([12345], dtype="i4")
+        fp.attrs["TIME"] = np.array([-321.9], dtype="f4")
+        fp.attrs["TIME UNITS"] = np.array([b"time unit"], dtype="|S256")
+
+        # dataset
+        # * osiris stores data like a fortran array
+        data = np.transpose(np.arange(24, dtype=dtype).reshape((2, 3, 4)))
+
+        fp.create_dataset("test ds", data=data)
+        fp.attrs["UNITS"] = np.array([b"test dataset unit"], dtype="|S256")
+
+        # axes
+        axis1_data = np.array([-1, 2], dtype=dtype)
+        axis2_data = np.array([-2, 3], dtype=dtype)
+        axis3_data = np.array([-3, 4], dtype=dtype)
+
+        axis_grp = fp.create_group("AXIS")
+        axis1 = axis_grp.create_dataset("AXIS1", data=axis1_data)
+        axis1.attrs["NAME"] = np.array([b"axis1 name"], dtype="|S256")
+        axis1.attrs["LONG_NAME"] = np.array([b"axis_1"], dtype="|S256")
+        axis1.attrs["UNITS"] = np.array([b"axis1 unit"], dtype="|S256")
+
+        axis2 = axis_grp.create_dataset("AXIS2", data=axis2_data)
+        axis2.attrs["NAME"] = np.array([b"axis2 name"], dtype="|S256")
+        axis2.attrs["LONG_NAME"] = np.array([b"axis_2"], dtype="|S256")
+        axis2.attrs["UNITS"] = np.array([b"axis2 unit"], dtype="|S256")
+
+        axis3 = axis_grp.create_dataset("AXIS3", data=axis3_data)
+        axis3.attrs["NAME"] = np.array([b"axis3 name"], dtype="|S256")
+        axis3.attrs["LONG_NAME"] = np.array([b"axis_3"], dtype="|S256")
+        axis3.attrs["UNITS"] = np.array([b"axis3 unit"], dtype="|S256")
+
+    return file_
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_dev_file):
+    """Check 'Osiris_Hdf5_GridFile' is a valid backend exclusively"""
+    assert (
+        Osiris_Dev_Hdf5_GridFile.is_valid_backend(os_hdf5_grid_dev_file) is True
+    )
+
+    # backend are registered automatically for GridDatasets
+    for (name, backend) in GridDataset.get_backends().items():
+        if name == Osiris_Dev_Hdf5_GridFile.name:
+            continue
+
+        assert backend.is_valid_backend(os_hdf5_grid_dev_file) is False
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_dataset_props(os_hdf5_grid_dev_file):
+    backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
+    # TODO: check if dataset name is valid identifier
+    assert backend.dataset_name == "test ds"
+    assert backend.dataset_label == "\\Latex test dataset label"
+    assert backend.dataset_unit == "test dataset unit"
+
+    assert backend.shape == (2, 3, 4)
+    assert backend.dtype == np.dtype("f4")
+    assert backend.ndim == 3
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_dev_file):
+    backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
+    # TODO: check if axis names are valid identifier
+    expected_names = ("axis1 name", "axis2 name", "axis3 name")
+    expected_labels = ("axis_1", "axis_2", "axis_3")
+    expected_units = ("axis1 unit", "axis2 unit", "axis3 unit")
+
+    np.testing.assert_array_equal(backend.axes_names, expected_names)
+    np.testing.assert_array_equal(backend.axes_labels, expected_labels)
+    np.testing.assert_array_equal(backend.axes_units, expected_units)
+
+    np.testing.assert_array_equal(backend.axes_min, [-1, -2, -3])
+    np.testing.assert_array_equal(backend.axes_max, [2, 3, 4])
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_iteration_props(os_hdf5_grid_dev_file):
+    backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
+    assert backend.iteration == 12345
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_time_props(os_hdf5_grid_dev_file):
+    backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
+    np.testing.assert_allclose(backend.time_step, -321.9)
+    assert backend.time_unit == "time unit"
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_GridFile_reading_data(os_hdf5_grid_dev_file):
+    backend = Osiris_Dev_Hdf5_GridFile(os_hdf5_grid_dev_file)
+    full_array = np.arange(24, dtype="f4").reshape((2, 3, 4))
+
+    # full array
+    np.testing.assert_array_equal(backend.get_data(), full_array)
+
+    # # subarray
+    # index = np.s_[1, :2, ::2]
+    # np.testing.assert_array_equal(
+    #     backend.get_data(indexing=index), full_array[index]
+    # )

--- a/tests/backends/osiris/test_GridFile.py
+++ b/tests/backends/osiris/test_GridFile.py
@@ -263,8 +263,8 @@ def test_Osiris_Dev_Hdf5_GridFile_reading_data(os_hdf5_grid_dev_file):
     # full array
     np.testing.assert_array_equal(backend.get_data(), full_array)
 
-    # # subarray
-    # index = np.s_[1, :2, ::2]
-    # np.testing.assert_array_equal(
-    #     backend.get_data(indexing=index), full_array[index]
-    # )
+    # subarray
+    index = np.s_[1, :2, ::2]
+    np.testing.assert_array_equal(
+        backend.get_data(indexing=index), full_array[index]
+    )

--- a/tests/backends/osiris/test_GridFile.py
+++ b/tests/backends/osiris/test_GridFile.py
@@ -4,15 +4,10 @@ import numpy as np
 import pytest
 
 from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_GridFile
-from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_ParticleFile
 from nata.backends.osiris.hdf5 import Osiris_Hdf5_GridFile
-from nata.backends.osiris.hdf5 import Osiris_Hdf5_ParticleFile
 from nata.backends.osiris.zdf import Osiris_zdf_GridFile
-from nata.backends.osiris.zdf import Osiris_zdf_ParticleFile
 from nata.containers import GridDataset
-from nata.containers import ParticleDataset
 from nata.types import GridBackendType
-from nata.types import ParticleBackendType
 
 
 def test_Osiris_Hdf5_GridFile_isinstance_GridBackendType():
@@ -33,29 +28,6 @@ def test_GridDatasets_backends_are_registered():
     assert backends[Osiris_Hdf5_GridFile.name] is Osiris_Hdf5_GridFile
     assert backends[Osiris_Dev_Hdf5_GridFile.name] is Osiris_Dev_Hdf5_GridFile
     assert backends[Osiris_zdf_GridFile.name] is Osiris_zdf_GridFile
-
-
-def test_Osiris_Hdf5_ParticleFile_ParticleBackendType():
-    assert isinstance(Osiris_Hdf5_ParticleFile, ParticleBackendType)
-
-
-def test_Osiris_Dev_Hdf5_ParticleFile_ParticleBackendType():
-    assert isinstance(Osiris_Dev_Hdf5_ParticleFile, ParticleBackendType)
-
-
-def test_Osiris_zdf_ParticleFile_ParticleBackendType():
-    assert isinstance(Osiris_zdf_ParticleFile, ParticleBackendType)
-
-
-def test_ParticleDatasets_backends_are_registered():
-    backends = ParticleDataset.get_backends()
-
-    assert backends[Osiris_Hdf5_ParticleFile.name] is Osiris_Hdf5_ParticleFile
-    assert (
-        backends[Osiris_Dev_Hdf5_ParticleFile.name]
-        is Osiris_Dev_Hdf5_ParticleFile
-    )
-    assert backends[Osiris_zdf_ParticleFile.name] is Osiris_zdf_ParticleFile
 
 
 @pytest.fixture(name="os_hdf5_grid_444_file", scope="session")

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import h5py as h5
+import numpy as np
+import pytest
+
 from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_ParticleFile
 from nata.backends.osiris.hdf5 import Osiris_Hdf5_ParticleFile
 from nata.backends.osiris.zdf import Osiris_zdf_ParticleFile
@@ -27,3 +31,33 @@ def test_ParticleDatasets_backends_are_registered():
         is Osiris_Dev_Hdf5_ParticleFile
     )
     assert backends[Osiris_zdf_ParticleFile.name] is Osiris_zdf_ParticleFile
+
+
+@pytest.fixture(name="os_hdf5_particle_444_file", scope="session")
+def _generate_valid_Osiris_Hdf5_ParticleFile(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("os_hdf5_grid_444_fixture")
+    file_ = tmp_path / "os_hdf5_particle_444_file.h5"
+
+    with h5.File(file_, mode="w") as fp:
+        # root attrs
+        fp.attrs["TYPE"] = np.array([b"particles"], dtype="|S9")
+
+    return file_
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_ParticleFile_check_is_valid_backend(
+    os_hdf5_particle_444_file,
+):
+    """Check 'Osiris_Hdf5_ParticleFile' is a valid backend exclusively"""
+    assert (
+        Osiris_Hdf5_ParticleFile.is_valid_backend(os_hdf5_particle_444_file)
+        is True
+    )
+
+    # backend are registered automatically for GridDatasets
+    for (name, backend) in ParticleDataset.get_backends().items():
+        if name == Osiris_Hdf5_ParticleFile.name:
+            continue
+
+        assert backend.is_valid_backend(os_hdf5_particle_444_file) is False

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -35,7 +35,7 @@ def test_ParticleDatasets_backends_are_registered():
 
 @pytest.fixture(name="os_hdf5_particle_444_file", scope="session")
 def _generate_valid_Osiris_Hdf5_ParticleFile(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("os_hdf5_grid_444_fixture")
+    tmp_path = tmp_path_factory.mktemp("os_hdf5_particle_444_fixture")
     file_ = tmp_path / "os_hdf5_particle_444_file.h5"
     dtype = np.dtype("f4")
 
@@ -82,7 +82,7 @@ def test_Osiris_Hdf5_ParticleFile_check_is_valid_backend(
         is True
     )
 
-    # backend are registered automatically for GridDatasets
+    # backend are registered automatically for ParticleDatasets
     for (name, backend) in ParticleDataset.get_backends().items():
         if name == Osiris_Hdf5_ParticleFile.name:
             continue

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -131,7 +131,7 @@ def test_Osiris_Hdf5_ParticleFile_time_props(os_hdf5_particle_444_file):
 
 
 @pytest.mark.wip
-def test_Osiris_Dev_Hdf5_GridFile_reading_data(os_hdf5_particle_444_file):
+def test_Osiris_Hdf5_ParticleFile_reading_data(os_hdf5_particle_444_file):
     """Check 'Osiris_Hdf5_ParticleFile' reading array correctly"""
     backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
     dtype = np.dtype([(quant, "f4") for quant in ("q", "quant1", "quant2")])
@@ -266,3 +266,39 @@ def test_Osiris_Dev_Hdf5_ParticleFile_time_props(os_hdf5_particle_dev_file):
     backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
     np.testing.assert_allclose(backend.time_step, -321.9)
     assert backend.time_unit == "time unit"
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_reading_data(os_hdf5_particle_dev_file):
+    """Check 'Osiris_Hdf5_ParticleFile' reading array correctly"""
+    backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
+    dtype = np.dtype([(quant, "f4") for quant in ("q", "quant1", "quant2")])
+
+    full_array = np.zeros(13, dtype=dtype)
+    full_array["q"] = np.arange(13, dtype="f4")
+    full_array["quant1"] = np.arange(13, dtype="f4") - 10
+    full_array["quant2"] = np.arange(13, dtype="f4") + 10
+
+    # full data
+    np.testing.assert_array_equal(backend.get_data(), full_array)
+
+    # --- subdata ---
+    # select every 2nd particle
+    index = np.s_[::2]
+    np.testing.assert_array_equal(
+        backend.get_data(indexing=index), full_array[index]
+    )
+    # select two quantities
+    np.testing.assert_array_equal(
+        backend.get_data(fields=["quant1", "quant2"]),
+        full_array[["quant1", "quant2"]],
+    )
+    # select one quantity
+    np.testing.assert_array_equal(
+        backend.get_data(fields="quant1"), full_array["quant1"],
+    )
+    # select one quantity and every 3rd particle
+    np.testing.assert_array_equal(
+        backend.get_data(indexing=index, fields="quant1"),
+        full_array["quant1"][index],
+    )

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_ParticleFile
+from nata.backends.osiris.hdf5 import Osiris_Hdf5_ParticleFile
+from nata.backends.osiris.zdf import Osiris_zdf_ParticleFile
+from nata.containers import ParticleDataset
+from nata.types import ParticleBackendType
+
+
+def test_Osiris_Hdf5_ParticleFile_ParticleBackendType():
+    assert isinstance(Osiris_Hdf5_ParticleFile, ParticleBackendType)
+
+
+def test_Osiris_Dev_Hdf5_ParticleFile_ParticleBackendType():
+    assert isinstance(Osiris_Dev_Hdf5_ParticleFile, ParticleBackendType)
+
+
+def test_Osiris_zdf_ParticleFile_ParticleBackendType():
+    assert isinstance(Osiris_zdf_ParticleFile, ParticleBackendType)
+
+
+def test_ParticleDatasets_backends_are_registered():
+    backends = ParticleDataset.get_backends()
+
+    assert backends[Osiris_Hdf5_ParticleFile.name] is Osiris_Hdf5_ParticleFile
+    assert (
+        backends[Osiris_Dev_Hdf5_ParticleFile.name]
+        is Osiris_Dev_Hdf5_ParticleFile
+    )
+    assert backends[Osiris_zdf_ParticleFile.name] is Osiris_zdf_ParticleFile

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -37,10 +37,16 @@ def test_ParticleDatasets_backends_are_registered():
 def _generate_valid_Osiris_Hdf5_ParticleFile(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("os_hdf5_grid_444_fixture")
     file_ = tmp_path / "os_hdf5_particle_444_file.h5"
+    dtype = np.dtype("f4")
 
     with h5.File(file_, mode="w") as fp:
         # root attrs
+        fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
         fp.attrs["TYPE"] = np.array([b"particles"], dtype="|S9")
+
+        # charge
+        data_q = np.arange(13, dtype=dtype)
+        fp.create_dataset("q", data=data_q)
 
     return file_
 
@@ -61,3 +67,11 @@ def test_Osiris_Hdf5_ParticleFile_check_is_valid_backend(
             continue
 
         assert backend.is_valid_backend(os_hdf5_particle_444_file) is False
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_ParticleFile_dataset_props(os_hdf5_particle_444_file):
+    """Check 'Osiris_Hdf5_ParticleFile' dataset properties"""
+    backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
+    assert backend.dataset_name == "test ds"
+    assert backend.num_particles == 13

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -46,7 +46,25 @@ def _generate_valid_Osiris_Hdf5_ParticleFile(tmp_path_factory):
 
         # charge
         data_q = np.arange(13, dtype=dtype)
-        fp.create_dataset("q", data=data_q)
+        q = fp.create_dataset("q", data=data_q)
+        q.attrs["LONG_NAME"] = np.array([b"q label"], dtype="|S256")
+        q.attrs["UNITS"] = np.array([b"q unit"], dtype="|S256")
+
+        # quant 1
+        data_quant1 = np.arange(13, dtype=dtype) - 10
+        quant1 = fp.create_dataset("quant1", data=data_quant1)
+        quant1.attrs["LONG_NAME"] = np.array([b"quant1 label"], dtype="|S256")
+        quant1.attrs["UNITS"] = np.array([b"quant1 unit"], dtype="|S256")
+
+        # quant 2
+        data_quant2 = np.arange(13, dtype=dtype) - 10
+        quant2 = fp.create_dataset("quant2", data=data_quant2)
+        quant2.attrs["LONG_NAME"] = np.array([b"quant2 label"], dtype="|S256")
+        quant2.attrs["UNITS"] = np.array([b"quant2 unit"], dtype="|S256")
+
+        # tags
+        tags = np.arange(13 * 2, dtype="i4").reshape((13, 2))
+        fp.create_dataset("tag", data=tags)
 
     return file_
 
@@ -75,3 +93,17 @@ def test_Osiris_Hdf5_ParticleFile_dataset_props(os_hdf5_particle_444_file):
     backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
     assert backend.dataset_name == "test ds"
     assert backend.num_particles == 13
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_ParticleFile_quantity_props(os_hdf5_particle_444_file):
+    """Check 'Osiris_Hdf5_ParticleFile' quantity properties"""
+    backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
+    # TODO: check if quantity names are valid identifier
+    expected_names = ("q", "quant1", "quant2")
+    expected_labels = ("q label", "quant1 label", "quant2 label")
+    expected_units = ("q unit", "quant1 unit", "quant2 unit")
+
+    np.testing.assert_array_equal(backend.quantity_names, expected_names)
+    np.testing.assert_array_equal(backend.quantity_labels, expected_labels)
+    np.testing.assert_array_equal(backend.quantity_units, expected_units)

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -96,6 +96,9 @@ def test_Osiris_Hdf5_ParticleFile_dataset_props(os_hdf5_particle_444_file):
     backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
     assert backend.dataset_name == "test ds"
     assert backend.num_particles == 13
+    assert backend.dtype == np.dtype(
+        [(s, "f4") for s in ("q", "quant1", "quant2")]
+    )
 
 
 @pytest.mark.wip

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -128,3 +128,105 @@ def test_Osiris_Hdf5_ParticleFile_time_props(os_hdf5_particle_444_file):
     backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
     np.testing.assert_allclose(backend.time_step, -321.9)
     assert backend.time_unit == "time unit"
+
+
+@pytest.fixture(name="os_hdf5_particle_dev_file", scope="session")
+def _generate_valid_Osiris_Dev_Hdf5_ParticleFile(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("os_hdf5_particle_dev_fixture")
+    file_ = tmp_path / "os_hdf5_particle_dev_file.h5"
+    dtype = np.dtype("f4")
+
+    with h5.File(file_, mode="w") as fp:
+        # root attrs
+        fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
+        fp.attrs["TYPE"] = np.array([b"particles"], dtype="|S9")
+        fp.attrs["QUANTS"] = np.array(
+            [b"q", b"quant1", b"quant2"], dtype="|S256"
+        )
+        fp.attrs["LABELS"] = np.array(
+            [b"q label", b"quant1 label", b"quant2 label"], dtype="|S256"
+        )
+        fp.attrs["UNITS"] = np.array(
+            [b"q unit", b"quant1 unit", b"quant2 unit"], dtype="|S256"
+        )
+        fp.attrs["ITER"] = np.array([12345], dtype="i4")
+        fp.attrs["TIME"] = np.array([-321.9], dtype="f4")
+        fp.attrs["TIME UNITS"] = np.array([b"time unit"], dtype="|S256")
+
+        # charge
+        data_q = np.arange(13, dtype=dtype)
+        fp.create_dataset("q", data=data_q)
+
+        # # quant 1
+        data_quant1 = np.arange(13, dtype=dtype) - 10
+        fp.create_dataset("quant1", data=data_quant1)
+
+        # # quant 2
+        data_quant2 = np.arange(13, dtype=dtype) + 10
+        fp.create_dataset("quant2", data=data_quant2)
+
+        # tags
+        tags = np.arange(13 * 2, dtype="i4").reshape((13, 2))
+        fp.create_dataset("tag", data=tags)
+
+    return file_
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_check_is_valid_backend(
+    os_hdf5_particle_dev_file,
+):
+    """Check 'Osiris_Dev_Hdf5_ParticleFile' is a valid backend exclusively"""
+    assert (
+        Osiris_Dev_Hdf5_ParticleFile.is_valid_backend(os_hdf5_particle_dev_file)
+        is True
+    )
+
+    # backend are registered automatically for ParticleDatasets
+    for (name, backend) in ParticleDataset.get_backends().items():
+        if name == Osiris_Dev_Hdf5_ParticleFile.name:
+            continue
+
+        assert backend.is_valid_backend(os_hdf5_particle_dev_file) is False
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_dataset_props(os_hdf5_particle_dev_file):
+    """Check 'Osiris_Dev_Hdf5_ParticleFile' dataset properties"""
+    backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
+    assert backend.dataset_name == "test ds"
+    assert backend.num_particles == 13
+    assert backend.dtype == np.dtype(
+        [(s, "f4") for s in ("q", "quant1", "quant2")]
+    )
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_quantity_props(os_hdf5_particle_dev_file):
+    """Check 'Osiris_Dev_Hdf5_ParticleFile' quantity properties"""
+    backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
+    # TODO: check if quantity names are valid identifier
+    expected_names = ("q", "quant1", "quant2")
+    expected_labels = ("q label", "quant1 label", "quant2 label")
+    expected_units = ("q unit", "quant1 unit", "quant2 unit")
+
+    np.testing.assert_array_equal(backend.quantity_names, expected_names)
+    np.testing.assert_array_equal(backend.quantity_labels, expected_labels)
+    np.testing.assert_array_equal(backend.quantity_units, expected_units)
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_iteration_props(
+    os_hdf5_particle_dev_file,
+):
+    """Check 'Osiris_Dev_Hdf5_ParticleFile' extraction of iteration"""
+    backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
+    assert backend.iteration == 12345
+
+
+@pytest.mark.wip
+def test_Osiris_Dev_Hdf5_ParticleFile_time_props(os_hdf5_particle_dev_file):
+    """Check 'Osiris_Dev_Hdf5_ParticleFile' extraction of time props"""
+    backend = Osiris_Dev_Hdf5_ParticleFile(os_hdf5_particle_dev_file)
+    np.testing.assert_allclose(backend.time_step, -321.9)
+    assert backend.time_unit == "time unit"

--- a/tests/backends/osiris/test_ParticleFile.py
+++ b/tests/backends/osiris/test_ParticleFile.py
@@ -43,6 +43,9 @@ def _generate_valid_Osiris_Hdf5_ParticleFile(tmp_path_factory):
         # root attrs
         fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
         fp.attrs["TYPE"] = np.array([b"particles"], dtype="|S9")
+        fp.attrs["ITER"] = np.array([12345], dtype="i4")
+        fp.attrs["TIME"] = np.array([-321.9], dtype="f4")
+        fp.attrs["TIME UNITS"] = np.array([b"time unit"], dtype="|S256")
 
         # charge
         data_q = np.arange(13, dtype=dtype)
@@ -107,3 +110,18 @@ def test_Osiris_Hdf5_ParticleFile_quantity_props(os_hdf5_particle_444_file):
     np.testing.assert_array_equal(backend.quantity_names, expected_names)
     np.testing.assert_array_equal(backend.quantity_labels, expected_labels)
     np.testing.assert_array_equal(backend.quantity_units, expected_units)
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_ParticleFile_iteration_props(os_hdf5_particle_444_file):
+    """Check 'Osiris_Hdf5_ParticleFile' extraction of iteration"""
+    backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
+    assert backend.iteration == 12345
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_ParticleFile_time_props(os_hdf5_particle_444_file):
+    """Check 'Osiris_Hdf5_ParticleFile' extraction of time props"""
+    backend = Osiris_Hdf5_ParticleFile(os_hdf5_particle_444_file)
+    np.testing.assert_allclose(backend.time_step, -321.9)
+    assert backend.time_unit == "time unit"

--- a/tests/backends/test_osiris_backends.py
+++ b/tests/backends/test_osiris_backends.py
@@ -58,9 +58,10 @@ def test_ParticleDatasets_backends_are_registered():
     assert backends[Osiris_zdf_ParticleFile.name] is Osiris_zdf_ParticleFile
 
 
-@pytest.fixture(name="os_hdf5_grid_444_file")
-def _generate_valid_Osiris_Hdf5_GridFile(tmp_path):
+@pytest.fixture(name="os_hdf5_grid_444_file", scope="session")
+def _generate_valid_Osiris_Hdf5_GridFile(tmp_path_factory):
     """Fixture for valid HDF5 file for Osiris_Hdf5_GridFile backend"""
+    tmp_path = tmp_path_factory.mktemp("os_hdf5_grid_444_fixture")
     file_ = tmp_path / "os_hdf5_grid_444_file.h5"
     dtype = np.dtype("f4")
 

--- a/tests/backends/test_osiris_backends.py
+++ b/tests/backends/test_osiris_backends.py
@@ -62,17 +62,51 @@ def test_ParticleDatasets_backends_are_registered():
 def _generate_valid_Osiris_Hdf5_GridFile(tmp_path):
     """Fixture for valid HDF5 file for Osiris_Hdf5_GridFile backend"""
     file_ = tmp_path / "os_hdf5_grid_444_file.h5"
+    dtype = np.dtype("f4")
 
     with h5.File(file_, mode="w") as fp:
+        # root attrs
         fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
         fp.attrs["TYPE"] = np.array([b"grid"], dtype="|S4")
-        # osiris stores data like a fortran array
-        data = np.asfortranarray(np.arange(24).reshape((2, 3, 4)))
-        fp.create_dataset("test ds", data=data)
+        fp.attrs["ITER"] = np.array([12345], dtype="i4")
+        fp.attrs["TIME"] = np.array([-321.9], dtype="f4")
+        fp.attrs["TIME UNITS"] = np.array([b"time unit"], dtype="|S256")
+
+        # dataset
+        # * osiris stores data like a fortran array
+        data = np.transpose(np.arange(24, dtype=dtype).reshape((2, 3, 4)))
+
+        ds = fp.create_dataset("test ds", data=data)
+        ds.attrs["LONG_NAME"] = np.array(
+            [b"\\Latex test dataset label"], dtype="|S256"
+        )
+        ds.attrs["UNITS"] = np.array([b"test dataset unit"], dtype="|S256")
+
+        # axes
+        axis1_data = np.array([-1, 2], dtype=dtype)
+        axis2_data = np.array([-2, 3], dtype=dtype)
+        axis3_data = np.array([-3, 4], dtype=dtype)
+
+        axis_grp = fp.create_group("AXIS")
+        axis1 = axis_grp.create_dataset("AXIS1", data=axis1_data)
+        axis1.attrs["NAME"] = np.array([b"axis1 name"], dtype="|S256")
+        axis1.attrs["LONG_NAME"] = np.array([b"axis_1"], dtype="|S256")
+        axis1.attrs["UNITS"] = np.array([b"axis1 unit"], dtype="|S256")
+
+        axis2 = axis_grp.create_dataset("AXIS2", data=axis2_data)
+        axis2.attrs["NAME"] = np.array([b"axis2 name"], dtype="|S256")
+        axis2.attrs["LONG_NAME"] = np.array([b"axis_2"], dtype="|S256")
+        axis2.attrs["UNITS"] = np.array([b"axis2 unit"], dtype="|S256")
+
+        axis3 = axis_grp.create_dataset("AXIS3", data=axis3_data)
+        axis3.attrs["NAME"] = np.array([b"axis3 name"], dtype="|S256")
+        axis3.attrs["LONG_NAME"] = np.array([b"axis_3"], dtype="|S256")
+        axis3.attrs["UNITS"] = np.array([b"axis3 unit"], dtype="|S256")
 
     return file_
 
 
+@pytest.mark.wip
 def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
     """Check 'Osiris_Hdf5_GridFile' is a valid backend exclusively"""
     assert Osiris_Hdf5_GridFile.is_valid_backend(os_hdf5_grid_444_file) is True
@@ -83,3 +117,45 @@ def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
             continue
 
         assert backend.is_valid_backend(os_hdf5_grid_444_file) is False
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_GridFile_dataset_props(os_hdf5_grid_444_file):
+    backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
+    # TODO: check if dataset name is valid identifier
+    assert backend.dataset_name == "test ds"
+    assert backend.dataset_label == "\\Latex test dataset label"
+    assert backend.dataset_unit == "test dataset unit"
+
+    assert backend.shape == (2, 3, 4)
+    assert backend.dtype == np.dtype("f4")
+    assert backend.ndim == 3
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_GridFile_grid_axes_props(os_hdf5_grid_444_file):
+    backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
+    # TODO: check if axis names are valid identifier
+    expected_names = ("axis1 name", "axis2 name", "axis3 name")
+    expected_labels = ("axis_1", "axis_2", "axis_3")
+    expected_units = ("axis1 unit", "axis2 unit", "axis3 unit")
+
+    np.testing.assert_array_equal(backend.axes_names, expected_names)
+    np.testing.assert_array_equal(backend.axes_labels, expected_labels)
+    np.testing.assert_array_equal(backend.axes_units, expected_units)
+
+    np.testing.assert_array_equal(backend.axes_min, [-1, -2, -3])
+    np.testing.assert_array_equal(backend.axes_max, [2, 3, 4])
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_GridFile_iteration_props(os_hdf5_grid_444_file):
+    backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
+    assert backend.iteration == 12345
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
+    backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
+    np.testing.assert_allclose(backend.time_step, -321.9)
+    assert backend.time_unit == "time unit"

--- a/tests/backends/test_osiris_backends.py
+++ b/tests/backends/test_osiris_backends.py
@@ -160,3 +160,18 @@ def test_Osiris_Hdf5_GridFile_time_props(os_hdf5_grid_444_file):
     backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
     np.testing.assert_allclose(backend.time_step, -321.9)
     assert backend.time_unit == "time unit"
+
+
+@pytest.mark.wip
+def test_Osiris_Hdf5_GridFile_reading_data(os_hdf5_grid_444_file):
+    backend = Osiris_Hdf5_GridFile(os_hdf5_grid_444_file)
+    full_array = np.arange(24, dtype="f4").reshape((2, 3, 4))
+
+    # full array
+    np.testing.assert_array_equal(backend.get_data(), full_array)
+
+    # subarray
+    index = np.s_[1, :2, ::2]
+    np.testing.assert_array_equal(
+        backend.get_data(indexing=index), full_array[index]
+    )

--- a/tests/backends/test_osiris_backends.py
+++ b/tests/backends/test_osiris_backends.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import h5py as h5
+import numpy as np
+import pytest
+
 from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_GridFile
 from nata.backends.osiris.hdf5 import Osiris_Dev_Hdf5_ParticleFile
 from nata.backends.osiris.hdf5 import Osiris_Hdf5_GridFile
@@ -52,3 +56,20 @@ def test_ParticleDatasets_backends_are_registered():
         is Osiris_Dev_Hdf5_ParticleFile
     )
     assert backends[Osiris_zdf_ParticleFile.name] is Osiris_zdf_ParticleFile
+
+
+@pytest.fixture(name="os_hdf5_grid_444_file")
+def _generate_valid_Osiris_Hdf5_GridFile(tmp_path):
+    file_ = tmp_path / "os_hdf5_grid_444_file.h5"
+
+    with h5.File(file_, mode="w") as fp:
+        fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
+        fp.attrs["TYPE"] = np.array([b"grid"], dtype="|S4")
+        data = np.asfortranarray(np.arange(24).reshape((2, 3, 4)))
+        fp.create_dataset("test ds", data=data)
+
+    return file_
+
+
+def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
+    assert Osiris_Hdf5_GridFile.is_valid_backend(os_hdf5_grid_444_file) is True

--- a/tests/backends/test_osiris_backends.py
+++ b/tests/backends/test_osiris_backends.py
@@ -60,11 +60,13 @@ def test_ParticleDatasets_backends_are_registered():
 
 @pytest.fixture(name="os_hdf5_grid_444_file")
 def _generate_valid_Osiris_Hdf5_GridFile(tmp_path):
+    """Fixture for valid HDF5 file for Osiris_Hdf5_GridFile backend"""
     file_ = tmp_path / "os_hdf5_grid_444_file.h5"
 
     with h5.File(file_, mode="w") as fp:
         fp.attrs["NAME"] = np.array([b"test ds"], dtype="|S256")
         fp.attrs["TYPE"] = np.array([b"grid"], dtype="|S4")
+        # osiris stores data like a fortran array
         data = np.asfortranarray(np.arange(24).reshape((2, 3, 4)))
         fp.create_dataset("test ds", data=data)
 
@@ -72,4 +74,12 @@ def _generate_valid_Osiris_Hdf5_GridFile(tmp_path):
 
 
 def test_Osiris_Hdf5_GridFile_check_is_valid_backend(os_hdf5_grid_444_file):
+    """Check 'Osiris_Hdf5_GridFile' is a valid backend exclusively"""
     assert Osiris_Hdf5_GridFile.is_valid_backend(os_hdf5_grid_444_file) is True
+
+    # backend are registered automatically for GridDatasets
+    for (name, backend) in GridDataset.get_backends().items():
+        if name == Osiris_Hdf5_GridFile.name:
+            continue
+
+        assert backend.is_valid_backend(os_hdf5_grid_444_file) is False


### PR DESCRIPTION
This PR moves all of our backend code for grids and particles to use prefetching (only for HDF5). It is another way of overcoming the issues connected to #58. In addition, indexing and reading fields from the backend is now properly implemented and tested.

Closes #58